### PR TITLE
주소 컨트롤러와 장바구니 컨트롤러 테스트 코드 생성 중 잘못된 점 발견

### DIFF
--- a/src/main/java/com/bestcommerce/customer/controller/account/AccountController.java
+++ b/src/main/java/com/bestcommerce/customer/controller/account/AccountController.java
@@ -19,8 +19,8 @@ public class AccountController {
     }
 
     @PostMapping("/check/email")
-    public Boolean checkEmail(@RequestParam("customerEmail") String customerEmail){
-        return accountService.isUsableEmail(customerEmail);
+    public Boolean checkEmail(@RequestBody CustomerDto customerDto){
+        return accountService.isUsableEmail(customerDto.getCustomerEmail());
     }
 
     @PostMapping("/register")

--- a/src/main/java/com/bestcommerce/customer/controller/address/AddressController.java
+++ b/src/main/java/com/bestcommerce/customer/controller/address/AddressController.java
@@ -34,12 +34,13 @@ public class AddressController {
 
     @PostMapping("/save")
     public void saveAddress(@RequestBody AddressDto addressDto){
+
         log.info("address put method");
         addressService.saveAddressByCustomerId(entityConverter.toAddress(addressDto, accountService.getOneCustomerInfo(addressDto.getCustomerId())));
     }
 
     @PostMapping("/get")
     public List<AddressDto> getAllAddress(@RequestBody CustomerDto customerDto){
-        return dtoConverter.toAddressDtoList(addressService.getAllAddressesByCustomer(accountService.getOneCustomerInfo(customerDto.getCustomerId())));
+        return dtoConverter.toAddressDtoList(addressService.getAllAddressesByCustomer(accountService.getOneCustomerInfo(customerDto.getCustomerEmail())));
     }
 }

--- a/src/main/java/com/bestcommerce/customer/domain/Cart.java
+++ b/src/main/java/com/bestcommerce/customer/domain/Cart.java
@@ -6,28 +6,28 @@ import javax.persistence.*;
 
 @Getter
 @Entity(name = "cart")
-public class Cart {
+public class Cart{
 
-    @Id
-    @Column(name = "cart_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long cartId;
-
-    @Column(name = "product_cnt")
-    private int productCount;
-
+    @EmbeddedId
+    private CartKey cartKey = new CartKey();
 
     @ManyToOne
     @JoinColumn(name = "cu_id")
+    @MapsId("customerId")
     private Customer customer;
 
     @ManyToOne
-    @JoinColumn(name = "size_id")
-    private Size size;
+    @JoinColumn(name = "product_id")
+    @MapsId("productId")
+    private Product product;
 
     @ManyToOne
-    @JoinColumn(name = "product_id")
-    private Product product;
+    @JoinColumn(name = "size_id")
+    @MapsId("sizeId")
+    private Size size;
+
+    @Column(name = "product_cnt")
+    private int productCount;
 
     public Cart(){
     }

--- a/src/main/java/com/bestcommerce/customer/domain/CartKey.java
+++ b/src/main/java/com/bestcommerce/customer/domain/CartKey.java
@@ -1,0 +1,46 @@
+package com.bestcommerce.customer.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class CartKey implements Serializable {
+
+    @Column(name = "cu_id")
+    private Long customerId;
+
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Column(name = "size_id")
+    private Long sizeId;
+
+    public CartKey() {
+
+    }
+
+    public CartKey(Long customerId, Long productId, Long sizeId) {
+        this.customerId = customerId;
+        this.productId = productId;
+        this.sizeId = sizeId;
+    }
+
+    @Override
+    public boolean equals(Object obj){
+        if (this == obj){
+            return true;
+        }
+        else if(obj == null || getClass() != obj.getClass()){
+            return false;
+        }
+        CartKey other = (CartKey) obj;
+        return Objects.equals(customerId, other.customerId) && Objects.equals(productId, other.productId) && Objects.equals(sizeId, other.sizeId);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(customerId,productId,sizeId);
+    }
+}

--- a/src/main/java/com/bestcommerce/customer/dto/CartDto.java
+++ b/src/main/java/com/bestcommerce/customer/dto/CartDto.java
@@ -14,5 +14,10 @@ public class CartDto {
 
     private Long productId;
 
-
+    public CartDto(int productCount, Long sizeId, Long customerId, Long productId) {
+        this.productCount = productCount;
+        this.sizeId = sizeId;
+        this.customerId = customerId;
+        this.productId = productId;
+    }
 }

--- a/src/main/java/com/bestcommerce/customer/repository/domain/AddressRepository.java
+++ b/src/main/java/com/bestcommerce/customer/repository/domain/AddressRepository.java
@@ -4,9 +4,13 @@ import com.bestcommerce.customer.domain.Address;
 import com.bestcommerce.customer.domain.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 public interface AddressRepository extends JpaRepository<Address, Long> {
 
     List<Address> getAddressesByCustomer(Customer customer);
+
+    @Transactional
+    void deleteAddressByAddrId(Long addr_id);
 }

--- a/src/main/java/com/bestcommerce/customer/repository/domain/CartRepository.java
+++ b/src/main/java/com/bestcommerce/customer/repository/domain/CartRepository.java
@@ -1,7 +1,10 @@
 package com.bestcommerce.customer.repository.domain;
 
 import com.bestcommerce.customer.domain.Cart;
+import com.bestcommerce.customer.domain.CartKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CartRepository extends JpaRepository<Cart, Long> {
+public interface CartRepository extends JpaRepository<Cart, CartKey> {
+
+
 }

--- a/src/main/java/com/bestcommerce/customer/repository/domain/CustomerRepository.java
+++ b/src/main/java/com/bestcommerce/customer/repository/domain/CustomerRepository.java
@@ -3,8 +3,13 @@ package com.bestcommerce.customer.repository.domain;
 import com.bestcommerce.customer.domain.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.transaction.Transactional;
+
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
     Customer findByCuEmail(String cu_email);
+
+    @Transactional
+    void deleteCustomerByCuEmail(String cu_email);
 }

--- a/src/main/java/com/bestcommerce/customer/service/account/AccountService.java
+++ b/src/main/java/com/bestcommerce/customer/service/account/AccountService.java
@@ -14,8 +14,7 @@ public class AccountService {
     }
 
     public Boolean isUsableEmail(String cu_email){
-        Customer customer = customerRepository.findByCuEmail(cu_email);
-        return customer != null;
+        return customerRepository.findByCuEmail(cu_email) == null;
     }
 
     public void save(Customer customer){

--- a/src/main/java/com/bestcommerce/customer/service/account/AccountService.java
+++ b/src/main/java/com/bestcommerce/customer/service/account/AccountService.java
@@ -29,4 +29,8 @@ public class AccountService {
     public Customer getOneCustomerInfo(String cu_email){
         return customerRepository.findByCuEmail(cu_email);
     }
+
+    public void deleteOneCustomer(String cu_email){
+        customerRepository.deleteCustomerByCuEmail(cu_email);
+    }
 }

--- a/src/main/java/com/bestcommerce/customer/service/address/AddressService.java
+++ b/src/main/java/com/bestcommerce/customer/service/address/AddressService.java
@@ -27,4 +27,8 @@ public class AddressService {
     public List<Address> getAllAddressesByCustomer(Customer customer){
         return addressRepository.getAddressesByCustomer(customer);
     }
+
+    public void deleteAddressByAddrId(Long addressId){
+        addressRepository.deleteAddressByAddrId(addressId);
+    }
 }

--- a/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
+++ b/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
@@ -70,12 +70,14 @@ public class AccountControllerTest {
         ResponseEntity<Object> response = restTemplate.postForEntity(testUrl, customerDto, Object.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(false);
 
         customerDto = new CustomerDto(testEmail02,"","","","",'N');
 
         response = restTemplate.postForEntity(testUrl, customerDto, Object.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(true);
 
     }
 }

--- a/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
+++ b/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
@@ -28,7 +28,6 @@ public class AccountControllerTest {
     @Autowired
     private AccountService accountService;
 
-
     @DisplayName("회원 가입 테스트")
     @Test
     public void insertAccountInfoTest() throws Exception{
@@ -58,6 +57,7 @@ public class AccountControllerTest {
 
         accountService.deleteOneCustomer(testEmail);
     }
+
     @DisplayName("유효한 이메일인지 체크하는 테스트")
     @Test
     public void checkValidEmailTest() throws Exception{

--- a/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
+++ b/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
@@ -58,4 +58,24 @@ public class AccountControllerTest {
 
         accountService.deleteOneCustomer(testEmail);
     }
+    @DisplayName("유효한 이메일인지 체크하는 테스트")
+    @Test
+    public void checkValidEmailTest() throws Exception{
+        String testEmail01 = "dudtkd0219@gmail.com";
+        String testEmail02 = "zzangman@gmail.com";
+
+        CustomerDto customerDto = new CustomerDto(testEmail01,"","","","",'N');
+        String testUrl = "http://localhost:"+port+"/account/check/email";
+
+        ResponseEntity<Object> response = restTemplate.postForEntity(testUrl, customerDto, Object.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        customerDto = new CustomerDto(testEmail02,"","","","",'N');
+
+        response = restTemplate.postForEntity(testUrl, customerDto, Object.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    }
 }

--- a/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
+++ b/src/test/java/com/bestcommerce/customer/controller/AccountControllerTest.java
@@ -1,4 +1,61 @@
 package com.bestcommerce.customer.controller;
 
+import com.bestcommerce.customer.domain.Customer;
+import com.bestcommerce.customer.dto.CustomerDto;
+import com.bestcommerce.customer.service.account.AccountService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.Rollback;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@Rollback
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AccountControllerTest {
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private AccountService accountService;
+
+
+    @DisplayName("회원 가입 테스트")
+    @Test
+    public void insertAccountInfoTest() throws Exception{
+
+        String testEmail = "customer01@naver.com";
+        String testPassword = "1234";
+        String testName = "테스트";
+        String testNumber = "010-1111-1111";
+        String testBirthDate = "20010913";
+        Character testAuthYn ='N';
+
+        CustomerDto customerDto = new CustomerDto(testEmail,testPassword,testName,testNumber,testBirthDate,testAuthYn);
+        String testUrl = "http://localhost:"+port+"/account/register";
+
+        ResponseEntity<Long> response = restTemplate.postForEntity(testUrl, customerDto, Long.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        Customer customer = accountService.getOneCustomerInfo(testEmail);
+
+        assertThat(customer.getCuEmail()).isEqualTo(testEmail);
+        assertThat(customer.getPassword()).isEqualTo(testPassword);
+        assertThat(customer.getCuName()).isEqualTo(testName);
+        assertThat(customer.getCuTelNumber()).isEqualTo(testNumber);
+        assertThat(customer.getBirthdate()).isEqualTo(testBirthDate);
+        assertThat(customer.getAuthYn()).isEqualTo(testAuthYn);
+
+        accountService.deleteOneCustomer(testEmail);
+    }
 }

--- a/src/test/java/com/bestcommerce/customer/controller/AddressControllerTest.java
+++ b/src/test/java/com/bestcommerce/customer/controller/AddressControllerTest.java
@@ -1,0 +1,84 @@
+package com.bestcommerce.customer.controller;
+
+import com.bestcommerce.customer.domain.Address;
+import com.bestcommerce.customer.dto.AddressDto;
+import com.bestcommerce.customer.dto.CustomerDto;
+import com.bestcommerce.customer.service.account.AccountService;
+import com.bestcommerce.customer.service.address.AddressService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.Rollback;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Rollback
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AddressControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private AccountService accountService;
+
+    @Autowired
+    private AddressService addressService;
+
+    @DisplayName("주소 저장 테스트")
+    @Test
+    public void saveAddressTest() throws Exception{
+
+        Long customerId = 1L;
+        String addr = "대구광역시 서초구 남천동 네컷아파트 403호";
+        Character represent = 'Y';
+        String zipcode = "23897";
+
+        AddressDto addressDto = new AddressDto(customerId, addr, represent, zipcode);
+
+        String testUrl = "http://localhost:"+port+"/address/save";
+
+        ResponseEntity<Object> response = restTemplate.postForEntity(testUrl, addressDto, Object.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        List<Address> addressList = addressService.getAllAddressesByCustomer(accountService.getOneCustomerInfo(customerId));
+
+        for(Address address : addressList){
+            if(address.getAddr().equals(addr)){
+                assertThat(address.getCustomer().getCuId()).isEqualTo(customerId);
+                assertThat(address.getRepYn()).isEqualTo(represent);
+                assertThat(address.getZipCode()).isEqualTo(zipcode);
+                addressService.deleteAddressByAddrId(address.getAddrId());
+                break;
+            }
+        }
+    }
+
+    @DisplayName("고객 정보로 주소 가져오는 테스트")
+    @Test
+    public void getAllAddressByCustomer() throws Exception{
+
+        String customerEmail = "dudtkd0219@gmail.com";
+
+        CustomerDto customerDto = new CustomerDto(customerEmail,"","","","",'0');
+
+        String testUrl = "http://localhost:"+port+"/address/get";
+
+        ResponseEntity<Object> response = restTemplate.postForEntity(testUrl, customerDto, Object.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        System.out.println(response.getBody());
+    }
+}

--- a/src/test/java/com/bestcommerce/customer/controller/CartControllerTest.java
+++ b/src/test/java/com/bestcommerce/customer/controller/CartControllerTest.java
@@ -41,19 +41,13 @@ public class CartControllerTest {
         int productCount = 4;
         Long sizeId = 1L;
         Long customerId = 1L;
-        Long productId = 1L;
+        Long productId = 3L;
 
         CartDto cartDto = new CartDto(productCount,sizeId,customerId,productId);
 
         String testUrl = "http://localhost:"+port+"/cart/put";
 
         ResponseEntity<Object> response = restTemplate.postForEntity(testUrl, cartDto, Object.class);
-
-        /*
-        * 
-        * !!!
-        * TODO 설계 허점
-        * */
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }

--- a/src/test/java/com/bestcommerce/customer/controller/CartControllerTest.java
+++ b/src/test/java/com/bestcommerce/customer/controller/CartControllerTest.java
@@ -1,0 +1,62 @@
+package com.bestcommerce.customer.controller;
+
+import com.bestcommerce.customer.dto.CartDto;
+import com.bestcommerce.customer.service.account.AccountService;
+import com.bestcommerce.customer.service.product.ProductSelectService;
+import com.bestcommerce.customer.service.size.SizeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.Rollback;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Rollback
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CartControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ProductSelectService productSelectService;
+
+    @Autowired
+    private AccountService accountService;
+
+    @Autowired
+    private SizeService sizeService;
+
+    @DisplayName("장바구니 담는 테스트")
+    @Test
+    public void insertAccountInfoTest() throws Exception {
+        int productCount = 4;
+        Long sizeId = 1L;
+        Long customerId = 1L;
+        Long productId = 1L;
+
+        CartDto cartDto = new CartDto(productCount,sizeId,customerId,productId);
+
+        String testUrl = "http://localhost:"+port+"/cart/put";
+
+        ResponseEntity<Object> response = restTemplate.postForEntity(testUrl, cartDto, Object.class);
+
+        /*
+        * 
+        * !!!
+        * TODO 설계 허점
+        * */
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+
+}


### PR DESCRIPTION
주소 컨트롤러와 관련 테스트 코드 작성함에 있어서는 문제가 없었습니다.

문제는 장바구니 컨트롤러 테스트 코드 생성 중에 문제를 발견하였는데,
일단 우리가 설계한 장바구니 엔티티 컬럼은 (id, product_id, customer_id, size_id, count) 이렇게 되어있는데
이 장바구니에 값을 넣을 때 (product_id, customer_id, size_id, count) 이 값만 넣고 id는 자동증가로 처리 했습니다.

장바구니에 보통 물건을 담을 때 같은 물건에 사이즈가 같으면 카운트 값만 증가시키면 되는데,
만약 저렇게 처리하면 id 값이 새로 생성되고 새로운 행의 삽입이 되어서 정합성이 안맞게 됩니다.
(1, 나이키신발, 제임스, 270, 1)
(2, 나이키신발, 제임스, 270, 1)
이렇게 엔티티 아이디 값만 다르고 나머지는 다 같은 행의 삽입이 되어버려서 고쳐야 됩니다.
주문 테이블도 아니고 장바구니 테이블인데다 수량에 대한 정보를 담을 수 있는 컬럼이 있는 테이블은 더더욱 말이 안되죠.

그래서 이것을 
1. 서버 단에서 로직으로 풀어낼지,
2. 기존의 주키인 id를 삭제하고 product_id, customer_id, size_id 를 묶은 복합 키로 설계할 지
이야기 나눠야 할 것 같습니다.